### PR TITLE
Add config change event and health check to service client

### DIFF
--- a/MareSynchronosServer/MareSynchronosShared/Services/MareConfigurationServiceClient.cs
+++ b/MareSynchronosServer/MareSynchronosShared/Services/MareConfigurationServiceClient.cs
@@ -22,6 +22,8 @@ public class MareConfigurationServiceClient<T> : IHostedService, IConfigurationS
     private readonly CancellationTokenSource _updateTaskCts = new();
     private bool _initialized = false;
     private readonly HttpClient _httpClient;
+    public event EventHandler ConfigChangedEvent;
+    private IDisposable _onChanged;
 
     private Uri GetRoute(string key, string value)
     {
@@ -43,6 +45,7 @@ public class MareConfigurationServiceClient<T> : IHostedService, IConfigurationS
         _logger = logger;
         _serverTokenGenerator = serverTokenGenerator;
         _httpClient = new();
+        _onChanged = config.OnChange((c) => { ConfigChangedEvent?.Invoke(this, EventArgs.Empty); });
     }
 
     public bool IsMain => false;
@@ -122,6 +125,52 @@ public class MareConfigurationServiceClient<T> : IHostedService, IConfigurationS
         }
     }
 
+    private Uri? GetBaseAddress()
+    {
+        if (_config.CurrentValue is ServerConfiguration sc) return sc.MainServerAddress;
+        if (_config.CurrentValue is MareConfigurationBase mb) return mb.MainServerAddress;
+        if (_config.CurrentValue is ServicesConfiguration svc) return svc.MainServerAddress;
+        if (_config.CurrentValue is StaticFilesServerConfiguration sfs) return sfs.MainFileServerAddress;
+        return null;
+    }
+
+    private async Task WaitForHealthAsync(CancellationToken ct)
+    {
+        var baseAddress = GetBaseAddress();
+        if (baseAddress == null) return;
+
+        Uri healthUri;
+        try
+        {
+            healthUri = new Uri(baseAddress, "health");
+        }
+        catch
+        {
+            return;
+        }
+
+        _logger.LogInformation("Waiting for configuration host health at {uri}", healthUri);
+        for (int i = 0; i < 120 && !ct.IsCancellationRequested; i++)
+        {
+            try
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Get, healthUri);
+                using var resp = await _httpClient.SendAsync(req, ct).ConfigureAwait(false);
+                if (resp.IsSuccessStatusCode)
+                {
+                    _logger.LogInformation("Configuration host is healthy");
+                    return;
+                }
+            }
+            catch
+            {
+                // ignore and retry
+            }
+
+            try { await Task.Delay(TimeSpan.FromSeconds(0.5), ct).ConfigureAwait(false); } catch { }
+        }
+    }
+
     private async Task UpdateRemoteProperties(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
@@ -176,6 +225,7 @@ public class MareConfigurationServiceClient<T> : IHostedService, IConfigurationS
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Starting MareConfigurationServiceClient");
+        await WaitForHealthAsync(cancellationToken).ConfigureAwait(false);
         _ = UpdateRemoteProperties(_updateTaskCts.Token);
         while (!_initialized && !cancellationToken.IsCancellationRequested) await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
     }
@@ -184,6 +234,7 @@ public class MareConfigurationServiceClient<T> : IHostedService, IConfigurationS
     {
         _updateTaskCts.Cancel();
         _httpClient.Dispose();
+        _onChanged?.Dispose();
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Introduces a ConfigChangedEvent and subscribes to configuration changes. Adds a health check for the configuration host before starting the update loop, and ensures proper disposal of the change subscription on shutdown.

Prevents blank/partial configuration at startup when the configuration host isn't ready yet, resulting in null/defaults being used until the next config grab cycle.