### PR TITLE
Fix connection issues once and for all

### DIFF
--- a/MareSynchronosServer/MareSynchronosServer/Hubs/MareHub.Functions.cs
+++ b/MareSynchronosServer/MareSynchronosServer/Hubs/MareHub.Functions.cs
@@ -202,6 +202,8 @@ public partial class MareHub
     private async Task UpdateUserOnRedis()
     {
         await _redis.AddAsync("UID:" + UserUID, UserCharaIdent, TimeSpan.FromSeconds(60), StackExchange.Redis.When.Always, StackExchange.Redis.CommandFlags.FireAndForget).ConfigureAwait(false);
+        await _redis.SetAddAsync($"connections:{UserCharaIdent}", Context.ConnectionId).ConfigureAwait(false);
+        await _redis.UpdateExpiryAsync($"connections:{UserCharaIdent}", TimeSpan.FromSeconds(60)).ConfigureAwait(false);
     }
 
     private async Task UserGroupLeave(GroupPair groupUserPair, List<PausedEntry> allUserPairs, string userIdent, string? uid = null)


### PR DESCRIPTION
+ Theory behind this is that on connect, they get a connection ID. On disconnect, that connection id is removed from their redis set. If they have no remaining keys, they're disposed, otherwise we can be sure they've reconnected and should not be disposed.